### PR TITLE
Change "Gtags" to " Gtags" for minor-mode name

### DIFF
--- a/gtags-mode.el
+++ b/gtags-mode.el
@@ -45,7 +45,7 @@
   :type 'string
   :local t)
 
-(defcustom gtags-mode-lighter "Gtags"
+(defcustom gtags-mode-lighter " Gtags"
   "Gtags executable."
   :type 'string
   :risky t)


### PR DESCRIPTION
There is a standard practice of adding a single space before minor-mode names. Added single space so that it looks good on mode-line.