### PR TITLE
Only run update on after-save-hook in Global projects.

### DIFF
--- a/gtags-mode.el
+++ b/gtags-mode.el
@@ -259,7 +259,7 @@ This iterates over the buffers and tries to reset
 ;; Hooks =============================================================
 (defun gtags-mode--after-save-hook ()
   "After save hook to update GLOBAL database with changed data."
-  (when (and buffer-file-name (gtags-mode--local-plist))
+  (when (and buffer-file-name (gtags-mode--get-plist buffer-file-name))
     (gtags-mode--exec-async
      'gtags-mode--global
      '("--single-update") (file-name-nondirectory buffer-file-name))))


### PR DESCRIPTION
Hi @Ergus ,

This is a small PR that fixes an issue (IMO) where gtags-mode's after-save-hook tries to call global or gtags even if the saved file is not in a project where global/gtags is active. Currently if you save a file in a random non-global project, gtags-mode will try to create a local-plist, which in turn calls global to provide the database location. That fails, and the user is shown the error in the echo area. This PR makes sure that the after-save-hook only proceeds if there is a gtags-mode-local-plist defined for the saved file.