### PR TITLE
Correct path to file when definition is found in GTAGSLIBPATH

### DIFF
--- a/gtags-mode.el
+++ b/gtags-mode.el
@@ -104,7 +104,7 @@ The address is absolute for remote hosts.")
   "Regex to filter the output with `gtags-mode--output-format-options'.")
 
 (defconst gtags-mode--output-format-options
-  '("--result=cscope" "--path-style=through" "--color=never")
+  '("--result=cscope" "--path-style=relative" "--color=never")
   "Command line options to use with `gtags-mode--output-format-regex'.")
 
 (defsubst gtags-mode--message (level format-string &rest args)
@@ -278,11 +278,11 @@ name, code, file, line."
 		       (funcall creator
 				(match-string-no-properties 2 line)   ;; name
 				(match-string-no-properties 4 line)   ;; code
-				(concat root (substring-no-properties
-					      line (1+ (match-beginning 1)) (match-end 1))) ;; file
+				(concat root (match-string-no-properties 1 line)) ;; file
 				(string-to-number (match-string-no-properties 3 line))))) ;; line
 		   (apply #'gtags-mode--exec-sync
-		    (append gtags-mode--output-format-options args `(,symbol)) )))
+			  (append '("--directory") `(,(file-local-name root))
+				  gtags-mode--output-format-options args `(,symbol)))))
     (error "Calling gtags-mode--filter-find-symbol without GTAGSROOT")
     nil))
 


### PR DESCRIPTION

Dear Maintainer,

First of all, thank you for this very useful package. I approve your design
decisions, particularly regarding the relying on existing and standard frontend
features provided by emacs.

However, I have found some issues, that I will try and address in different pull
requests, that may have interdependencies.

This is the first one, the most important.

As of now, `gtags-mode` is not capable of jumping to the definition of a symbol
that is not in the current project, but in another project pointed to by the
`GTAGSLIBPATH` environment variable. Trying `xref-find-definitions` on a symbol
defined in such a project will most often create a new empty file in the current
project, since the path returned by `global` in such a case is to be interpreted
relative to the directory pointed by `GTAGSLIBPATH`, not the root of the current
project.

This is due to the fact that the `--path-style=through` option of `global`
always prints the path as it is found in the `GPATH` file **of the project the
symbol was found in**, which is not necessarily equivalent to "relative from the
project root I am currently in".

See https://lists.gnu.org/archive/html/bug-global/2025-05/msg00000.html and
https://lists.gnu.org/archive/html/bug-global/2025-05/msg00001.html for a
discussion with the upstream maintainer of GNU Global about this behaviour. As
you will see, the maintainer contends that this option is not to be used when
`GTAGSLIBPATH` is set, and proposes to unset `GTAGSLIBPATH` when `--path-style`
is `through`.

I understand you want to always print paths as relative to the root of the
project you are currently in. I agree with this, as it makes things easier for
`tramp` support, among other things.

The best way to do this, in my opinion, is to use `--path-style=relative` (which
can be omitted, it being the default) in conjunction with `-C` or `--directory`
pointing to the project root. This preserves the current behaviour, **and**
prints the correct path to external source files as well.

As an added benefit, this allows to correctly interpret relative paths in the
`GTAGSLIBPATH`, if those are set in the `gtags.conf` file of the project root,
like so :

```termcap
default:\
	:GTAGSLIBPATH=../some/library/directory\
	:tc=default@/etc/gtags/gtags.conf:
```

Please let me know if anything is unclear.

Best regards,

Aymeric

P.S. I see the copyright to the FSF. I already have a copyright assignment to
the FSF.