### PR TITLE
Correct completion function to offer completions from GTAGSLIBPATH

### DIFF
--- a/gtags-mode.el
+++ b/gtags-mode.el
@@ -261,9 +261,16 @@ completions usually from the cache when possible."
     (error "Calling `gtags-mode--list-completions' with no gtags-mode--plist"))
    ((and (stringp prefix)
 	 (not (string-match-p "\\`[ \t\n\r-]*\\'" prefix)) ;; not match empty or only -
-	 (gtags-mode--exec-sync "--ignore-case" "--completion" prefix)))
+	 (gtags-mode--exec-sync "--directory"
+				(file-local-name
+				 (plist-get (gtags-mode--local-plist default-directory) :gtagsroot))
+				"--ignore-case" "--through" "--completion" prefix)))
    ((plist-get gtags-mode--plist :cache))
-   (t (plist-put gtags-mode--plist :cache (gtags-mode--exec-sync "--completion"))
+   (t (plist-put gtags-mode--plist :cache
+		 (gtags-mode--exec-sync "--directory"
+					(file-local-name
+					 (plist-get (gtags-mode--local-plist default-directory) :gtagsroot))
+					"--through" "--completion"))
       (plist-get gtags-mode--plist :cache))))
 
 (defun gtags-mode--filter-find-symbol (args symbol creator)


### PR DESCRIPTION
Hi,

This is the third patch offer in the series.

At the moment, the completion function only offers completions for symbols that
are found in the current project.

It would be nice to make sure that symbols from the libraries pointed to by
`GTAGSLIBPATH` are offered as well.

The paths put in `GTAGSLIBPATH` are not always absolute, they can be relative to
the root of the project. More specifically, they can be relative to the
`gtags.conf` file at the root of the project :

```
default:\
	:GTAGSLIBPATH=../rico_igraph_libs/\:/usr/local/src/igraph/igraph/:\
	:tc=default@/etc/gtags/gtags.conf:
```

The only way to ensure that the files containing the completion candidates are
found by `global` is to move to the root of the project before launching the
`global` command.

The PR uses the `--directory` option to do just that.

For the same reason, I have also added the `--through` option to make sure that
all possible completions are proposed.

The PR should be compatible with tramp, I have made sure to remove the remote
part of the file.

With the PR, when I am editing some code file in the `src` directory of the
project whose `gtags.conf` I have written above, I am proposed completions from
both the library pointed to by the relative path (`../rico_igraph_libs`) and the
absolute one (`/usr/local/src/igraph/igraph/`).

This was not the case before.

Best,

Aymeric