### PR TITLE
Add annotation function for capf

### DIFF
--- a/gtags-mode.el
+++ b/gtags-mode.el
@@ -89,6 +89,10 @@ This variable must be set before enabling gtags-mode"
   :type 'natnum
   :risky t)
 
+(defcustom gtags-mode-use-annotation t
+  "Whether to use annotation on completions."
+  :type 'boolean)
+
 (defvar gtags-mode--alist nil
   "Full list of Global roots.
 The address is absolute for remote hosts.")
@@ -406,13 +410,29 @@ Return as a list of xref location objects."
 		(buffer-list))))
 
 ;; Completion-at-point-function (capf) ===============================
+(defun gtags-mode-annotation-function (string)
+  "Generate completion annotation.
+The annotation is defined as the substring of STRING beginning with the
+first opening parenthesis, and until either the first closing
+parenthesis, or the end of STRING, whatever comes first."
+  (when gtags-mode-use-annotation
+    (and-let*
+	((whole (car (gtags-mode--filter-find-symbol
+		      '("--definition") string
+		      (lambda (_name code _file _line)
+			code))))
+	 (index (or (string-match "\\(([^)]*)\\)" whole) ; try first with closing parenthesis
+		    (string-match "\\((.*\\)$" whole)))  ; then take until end of string
+	 (output (concat " " (match-string-no-properties 1 whole)))))))
+
 (defun gtags-mode-completion-function ()
   "Generate completion list."
   (if (gtags-mode--local-plist default-directory)
       (when-let* ((bounds (bounds-of-thing-at-point 'symbol)))
 	(list (car bounds) (point)
 	      (completion-table-dynamic #'gtags-mode--list-completions)
-	      :exclusive 'no))))
+	      :exclusive 'no
+	      :annotation-function #'gtags-mode-annotation-function))))
 
 (defmacro gtags-mode--with-feature (feature &rest body)
   (declare (indent 1) (debug t))


### PR DESCRIPTION
Hi !

This is the fourth patch in the series. The contributions from now on will be
feature additions rather than bugfixes. For this reason, I will create the PRs
as drafts, as some fine-tuning may be required before merging.

The point of this patch is to add a simple annotation function to the
completion-at-point function.

The purpose of the annotation function is simply to display a string next to the
completion, as described in the docstring of `completion-extra-properties`.

The annotation that is frequently provided by other packages (`company-gtags`,
for instance) is the signature of the function, when the completion is a
function name.

It would be very easy for us to provide such a feature, in a completely standard
way, keeping the spirit of your package. Various completion frontends would then
be free to display those annotations or not.

As explained in the docstring of `completion-extra-properties`, the annotation
function is to take a single argument, a completion string (a symbol name, in
our case), and return either `nil` (to say it has nothing to display) or a
string to be displayed.

In order to provide the definition of the function as annotation, the idea is to
simply call `global`, take only the "code" part of the output, and then finding
the substring of that part that starts with an opening parenthesis and ends with
either a closing parenthesis or the end of the line. If any of these operations
fail, the function returns `nil`.

So we are implicitly making the assumption that function parameters are enclosed
in parentheses, which is very often the case.

I was thinking that it would maybe be nice to be able to enable/disable this
feature with a custom variable. I can add it if you think it is interesting.

Best,

Aymeric

P.S. The discussion about the [point](https://github.com/Ergus/gtags-mode/pull/10#issuecomment-2888684668) you raised regarding `global` 
behaviour w.r.t. `GTAGSLIBPATH` continues in #10, if you wish.

